### PR TITLE
fix pattern matching non-exhaustive warning

### DIFF
--- a/app/GHCi/DAP/Command.hs
+++ b/app/GHCi/DAP/Command.hs
@@ -22,7 +22,6 @@ import GHCi.DAP.Type
 import GHCi.DAP.Constant
 import GHCi.DAP.Utility
 import qualified Haskell.DAP as D
-import Data.Maybe (fromJust)
 
 
 -- |
@@ -1123,17 +1122,19 @@ sourceCmd_ :: D.SourceRequestArguments
           -> Gi.GHCi (Either String D.SourceResponseBody)
 sourceCmd_ args = do
   modSums <- Gi.getLoadedModules
-  let srcInfo = fromJust $ D.sourceSourceRequestArguments args
-      srcPath = D.pathSource srcInfo
-      modPaths = map takeModPath modSums
-      summary = L.find (\sum -> G.ms_hspp_file sum == srcPath) modSums
-  case summary of
-    Nothing -> throwError $ "<sourceCmd_> loaded module can not find from path. <" ++ srcPath ++ "> " ++  show modPaths
-    Just summary -> do
-      case G.ms_hspp_buf summary of
+  case D.sourceSourceRequestArguments  args of
+    Nothing -> throwError "<sourceCmd_> deprecated data: sourceReference property in SourceRequest is not supported"
+    Just srcInfo -> do
+      let srcPath = D.pathSource srcInfo
+          modPaths = map takeModPath modSums
+          summary = L.find (\sum -> G.ms_hspp_file sum == srcPath) modSums
+      case summary of
         Nothing -> throwError $ "<sourceCmd_> loaded module can not find from path. <" ++ srcPath ++ "> " ++  show modPaths
-        Just strBuf -> do
-          let content = SB.lexemeToString strBuf (SB.len strBuf)
-          return $ Right D.defaultSourceResponseBody {
-              D.contentSourceResponseBody = content
-            }
+        Just summary -> do
+          case G.ms_hspp_buf summary of
+            Nothing -> throwError $ "<sourceCmd_> loaded module can not find from path. <" ++ srcPath ++ "> " ++  show modPaths
+            Just strBuf -> do
+              let content = SB.lexemeToString strBuf (SB.len strBuf)
+              return $ Right D.defaultSourceResponseBody {
+                  D.contentSourceResponseBody = content
+                }

--- a/app/GHCi/DAP/Command.hs
+++ b/app/GHCi/DAP/Command.hs
@@ -22,6 +22,7 @@ import GHCi.DAP.Type
 import GHCi.DAP.Constant
 import GHCi.DAP.Utility
 import qualified Haskell.DAP as D
+import Data.Maybe (fromJust)
 
 
 -- |
@@ -1122,7 +1123,7 @@ sourceCmd_ :: D.SourceRequestArguments
           -> Gi.GHCi (Either String D.SourceResponseBody)
 sourceCmd_ args = do
   modSums <- Gi.getLoadedModules
-  let Just srcInfo =  D.sourceSourceRequestArguments args
+  let srcInfo = fromJust $ D.sourceSourceRequestArguments args
       srcPath = D.pathSource srcInfo
       modPaths = map takeModPath modSums
       summary = L.find (\sum -> G.ms_hspp_file sum == srcPath) modSums


### PR DESCRIPTION
https://github.com/phoityne/ghci-dap/pull/8 introduces the following warning.
```
Building executable 'ghci-dap' for ghci-dap-0.0.20.0..
[11 of 14] Compiling GHCi.DAP.Command ( app/GHCi/DAP/Command.hs, dist/build/ghci-dap/ghci-dap-tmp/GHCi/DAP/Command.o )

app/GHCi/DAP/Command.hs:1125:7: warning: [-Wincomplete-uni-patterns]
    Pattern match(es) are non-exhaustive
    In a pattern binding:
        Patterns of type ‘Maybe D.Source’ not matched: Nothing
     |
1125 |   let Just srcInfo =  D.sourceSourceRequestArguments args
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

This PR fixed the above warning.