### PR TITLE
Fix loading of modules that use CPP

### DIFF
--- a/app/GHCi/DAP/Command.hs
+++ b/app/GHCi/DAP/Command.hs
@@ -207,7 +207,7 @@ setBpCmd_ args =
     -- |
     --
     takeModPath :: GAC.ModSummary -> (ModuleName, FilePath)
-    takeModPath ms = (G.moduleNameString (G.ms_mod_name ms), G.ms_hspp_file ms)
+    takeModPath ms = (G.moduleNameString (G.ms_mod_name ms), GAC.msHsFilePath ms)
 
 
     -- |


### PR DESCRIPTION
Using hspp to find module by path doesn't work on modules with CPP because any .hs module that does get preprocessed will be written to a file in a temporary directory afterwards and no longer match the original source file path.

This fixes setting breakpoints on modules that use CPP.